### PR TITLE
skip bugging executions

### DIFF
--- a/scripts/circuit_depth_and_gate_count.py
+++ b/scripts/circuit_depth_and_gate_count.py
@@ -42,12 +42,14 @@ for arch in ARCHITECTURES:
     # TODO: use irange instead
     for i in range(SAMPLE_SIZE):
         # transpile
-        try:
-            result = transpile(circuit, coupling_map=coupling_map, optimization_level=3,
-                               seed_transpiler=i)
-        except TranspilerError:
-            result = transpile(circuit, coupling_map=coupling_map, optimization_level=3,
-                               seed_transpiler=i+SAMPLE_SIZE)
+        result = None
+        while result is None:
+            try:
+                result = transpile(circuit, coupling_map=coupling_map, optimization_level=3,
+                                   seed_transpiler=i)
+                # print('seed_transpiler: ', i)
+            except TranspilerError:
+                i += SAMPLE_SIZE
         circuit_depth.append(result.depth())
         gate_count.append(sum(result.count_ops().values()))
 

--- a/scripts/circuit_depth_and_gate_count.py
+++ b/scripts/circuit_depth_and_gate_count.py
@@ -18,7 +18,7 @@ from pyzx import routing
 from qiskit import qiskit
 from qiskit import QuantumCircuit
 from qiskit import transpile
-from qiskit.transpiler import CouplingMap
+from qiskit.transpiler import CouplingMap, TranspilerError
 
 SAMPLE_SIZE = 100
 ARCHITECTURES = ['ibm_rochester', 'rigetti_16q_aspen']
@@ -42,7 +42,12 @@ for arch in ARCHITECTURES:
     # TODO: use irange instead
     for i in range(SAMPLE_SIZE):
         # transpile
-        result = transpile(circuit, coupling_map=coupling_map, optimization_level=3)
+        try:
+            result = transpile(circuit, coupling_map=coupling_map, optimization_level=3,
+                               seed_transpiler=i)
+        except TranspilerError:
+            result = transpile(circuit, coupling_map=coupling_map, optimization_level=3,
+                               seed_transpiler=i+SAMPLE_SIZE)
         circuit_depth.append(result.depth())
         gate_count.append(sum(result.count_ops().values()))
 


### PR DESCRIPTION
With `qiskit-terra==0.23.3`, in the iteration `i==18`, there is a bug in Qiskit that fails like this:
```
qiskit.transpiler.exceptions.TranspilerError: "'swap' would be supported on '(15, 14)' if the direction were swapped, but no rules are known to do that. ['cz', 'rzz', 'swap', 'ryy', 'ecr', 'rzx', 'rxx', 'cx'] can be automatically flipped."
```

This PR skips that case and other `TranspilerError`s.