### PR TITLE
Setup Bot actions

### DIFF
--- a/.github/workflows/run_experiments.yml
+++ b/.github/workflows/run_experiments.yml
@@ -1,4 +1,4 @@
-name: Run benchmark experiments and submit results to metriq.info
+name: Check for new qiskit versions, run benchmark experiments and submit results to metriq.info
 
 on:
   schedule:
@@ -15,13 +15,18 @@ jobs:
       METRIQ_TOKEN: ${{ secrets.METRIQ_TOKEN}}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Setup repository on this workflow
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
+      
+      - name: Install and configure Github CLI
+        uses: cli/cli/setup@v2
+        with:
+          gh-version: 2
       
       - name: Install tox
         run: pip install tox 
@@ -29,22 +34,26 @@ jobs:
       - name: Run experiment steps in tox
         run: tox -ve py38
 
-      # TODO: Create Github Bot account
-      # - name: Configure Git with Bot Git Config
-      #   run: |
-      #     git config user.name "${{ secrets.BOT_USERNAME }}"
-      #     git config user.email "${{ secrets.BOT_EMAIL }}"
+      - name: Configure Git with Bot Git Config
+        run: |
+          git config user.name "${{ secrets.BOT_USERNAME }}"
+          git config user.email "${{ secrets.BOT_EMAIL }}"
 
-      # - name: Check for new CSV files and commit with Bot user
-      #   run: |
-      #     untracked_csv_files=$(find ./benchmarking/results/ -name '*.csv' -type f)
-      #     if [ -n "$untracked_csv_files" ]; then
-      #       git add $untracked_csv_files
-      #       git commit -m "Add new result files"
-      #       git push -u origin main
-      #     fi
-      #   env:
-      #     BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
-      #     BOT_EMAIL: ${{ secrets.BOT_EMAIL }}
-      #     BOT_PAT: ${{ secrets.BOT_PAT}}
+      - name: Check for updates on result files and open new PR with Bot user
+        run: |
+          untracked_csv_files=$(find ./benchmarking/results/ -name '*.csv' -type f)
+          deleted_csv_files=$(git diff --name-only HEAD@{1} HEAD | grep -E '^../results/.*\.csv')
+          if [ -n "$untracked_csv_files" ] || [ -n "deleted_csv_files"]; then
+            git checkout -b bot-branch
+            git add $untracked_csv_files
+            git rm $deleted_csv_files
+            git commit -m "Add new result files"
+            git push --set-upstream origin bot-branch
+            gh pr create --base main --head bot-branch --title "Add new result files"
+            git checkout main
+          fi
+        env:
+          BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
+          BOT_EMAIL: ${{ secrets.BOT_EMAIL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
 

--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -1,4 +1,3 @@
-
 import os
 from metriq import MetriqClient
 from qiskit_versions import *
@@ -17,7 +16,7 @@ def get_qiskit_version_from_result(result_item: dict) -> str:
   # Get substring after last colon
   return notes.rsplit(":", 1)[1]
 
-def get_submissions_filtered_data() -> {}:
+def get_submissions_update_info() -> {}:
   # Fetch latest qiskit version
   latest_qiskit_version = find_latest_version(get_qiskit_versions_list())
 
@@ -34,9 +33,9 @@ def get_submissions_filtered_data() -> {}:
       submissions.append(get_qiskit_version_from_result(res))
     qiskit_versions_submitted[submission_id] = submissions
 
-  submissions_filtered_data = {}
+  submissions_update_info = {}
 
-  # Find qiskit versions to be either added or replaced in metriq
+  # Find new qiskit versions to be either added or replaced in metriq
   for key, value in qiskit_versions_submitted.items():
     latest_submitted_version = find_latest_version(value)
     versions_to_be_added = []
@@ -51,9 +50,9 @@ def get_submissions_filtered_data() -> {}:
       if same_minor(latest_qiskit_version, latest_submitted_version):
         versions_to_be_replaced.append(latest_submitted_version)  
 
-    submissions_filtered_data[key] = {"add": versions_to_be_added, "replace": versions_to_be_replaced}
+    submissions_update_info[key] = {"add": versions_to_be_added, "replace": versions_to_be_replaced}
   
-  return submissions_filtered_data
+  return submissions_update_info
 
 def delete_submission_results(submission_id: str, qiskit_version: str):
   client = MetriqClient(token=METRIQ_TOKEN)


### PR DESCRIPTION
This PR configures github actions to allow a bot user `qiskit-metriq-bot` to handle file updates after automated experiment runs (execute-workflow).
For new experiments on new qiskit versions, outdated csv files in `results` folder may need to be replaced. In this case, `qiskit-metriq-bot` is configured to open a new PR in this repository whenever new results are submitted to [metriq.info](https://metriq.info/).
In addition, existing variables were renamed to enhance code readability, and new print statements added to help debugging.

Closes #35 