### PR TITLE
Fix Qiskit version filtering bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Compiled for the IBMQ Rochester architecture
 * Python 3.11+
 
 ## Run locally
-### To run a benchmark experiment using the current stable version of `Qiskit`:
+### To run a benchmark experiment using the latest version of `Qiskit`(RCs excluded):
 ```bash
-tox -e qiskit-compilation
+tox -e py311
 ```
 **Note:**
-To run a specific version of `qiskit-terra`, you can manually update it in the `tox.ini` file.
-Versions >=0.13,<=0.15 require numpy<1.20. You can run the tox environments `terra13`, `terra14` or `terra15` as:
+To run a specific version of `Qiskit`, you can manually update the `tox.ini` file with the required version.
+Versions >=0.13,<=0.15 require numpy<1.20 and python<=3.8. You can run the tox environments `terra13`, `terra14` or `terra15` as:
 ```bash
-tox -e qiskit-compilation-terra13
+tox -e py38-terra13
 ```

--- a/src/qiskit_versions.py
+++ b/src/qiskit_versions.py
@@ -81,10 +81,12 @@ def filter_by_date(data_items: dict, min_date: [], max_date: []) -> []:
     temp = {}
 
     for release, release_info in data_items:
-        # Skip RCs
-        if "rc" in release:
-            continue
 
+        # Skip RCs and pre-releases
+        if "rc" in release or "b" in release:
+            print("Skipping version ", release)
+            continue
+        
         date_str = release_info[0]["upload_time"]
         dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S")
         year = dt.year

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,18 @@
 
 [tox]
 minversion = 3.11
-envlist = py311, qiskit-compilation, {qiskit-compilation}-terra{13,14,15,25}
+envlist = py311, {py38}-terra{13,14,15,25}
 
 [testenv]
-description = run circuit benchmark steps and submit results to metriq
+description = Run end-to-end benchmark steps and submit results to Metriq
 deps =
     qiskit
+    terra13: qiskit-terra==0.13.0
+    terra14: qiskit-terra==0.14.2
+    terra15: qiskit-terra==0.15.2
+    terra25: qiskit-terra==0.25.0
+    terra13,terra14,terra15: numpy<1.20
+    terra25: qiskit==0.44.0
     requests
     pyzx
     pandas
@@ -17,16 +23,3 @@ passenv = METRIQ_TOKEN
 commands =
     pip install --upgrade https://github.com/unitaryfund/metriq-client/tarball/development
     python {toxinidir}/src/run_experiment_steps.py
-
-[testenv:qiskit-compilation]
-basepython = python3.8
-deps=
-    terra13: qiskit-terra==0.13.0
-    terra14: qiskit-terra==0.14.2
-    terra15: qiskit-terra==0.15.2
-    terra25: qiskit-terra==0.25.0
-    terra13,terra14,terra15: numpy<1.20
-    terra25: qiskit==0.44.0
-    {[testenv]deps}
-commands = 
-    python {toxinidir}/src/circuit_depth_and_gate_count.py


### PR DESCRIPTION
This PR:
- Filters out Qiskit pre-release versions ( Fixes #44 )
- Simplify tox environments + doc update